### PR TITLE
feat: agent-readable site (llms.txt, skills.md, clean markdown content URLs)

### DIFF
--- a/src/config/skills.ts
+++ b/src/config/skills.ts
@@ -1,0 +1,37 @@
+// Registry of installable Codealoy skill artifacts.
+//
+// The skills themselves live in a dedicated public repository so they can be
+// versioned and installed independently of the site. `skills.md` (served at the
+// site root) is generated from this list — keep the list as the single source
+// of truth rather than editing the generated file by hand.
+
+export const SKILLS_REPO_URL = 'https://github.com/codealoy/skills';
+
+export type SkillStatus = 'available' | 'planned';
+
+export type SkillArtifact = {
+  /** Slash command users invoke, e.g. '/bujhiye-bolo'. */
+  command: string;
+  /** Bangla name. */
+  name: string;
+  /** Short Bangla description. */
+  description: string;
+  /** Short English description. */
+  descriptionEn: string;
+  status: SkillStatus;
+  /** Link to the skill inside the skills repo (or the repo itself). */
+  url: string;
+};
+
+export const SKILLS: SkillArtifact[] = [
+  {
+    command: '/bujho',
+    name: 'বুঝিয়ে বলো',
+    description:
+      'যেকোনো কোড বা এরর সহজ বাংলায় বুঝিয়ে বলে — প্রতিটি লাইন, উদাহরণসহ।',
+    descriptionEn:
+      'Explains any code or error in plain Bangla, line by line, with examples.',
+    status: 'planned',
+    url: SKILLS_REPO_URL,
+  },
+];

--- a/src/lib/agentReadable.ts
+++ b/src/lib/agentReadable.ts
@@ -1,0 +1,60 @@
+import { BASE_URL } from '@/config/site';
+
+/**
+ * Build an absolute URL from a site-relative path.
+ * Example: absoluteUrl('/blog/welcome.md') -> 'https://www.codealoy.com/blog/welcome.md'
+ */
+export function absoluteUrl(path: string): string {
+  return new URL(path, BASE_URL).href;
+}
+
+type ContentMarkdownInput = {
+  title: string;
+  description?: string;
+  body: string;
+  canonicalPath: string;
+  meta?: Record<string, string | undefined>;
+};
+
+/**
+ * Wrap a raw markdown body with a small, human-readable header (title,
+ * description and a few metadata lines) for AI/agent consumption.
+ */
+export function buildContentMarkdown({
+  title,
+  description,
+  body,
+  canonicalPath,
+  meta = {},
+}: ContentMarkdownInput): string {
+  const lines: string[] = [`# ${title}`, ''];
+
+  if (description) {
+    lines.push(`> ${description}`, '');
+  }
+
+  for (const [key, value] of Object.entries(meta)) {
+    if (value) {
+      lines.push(`- **${key}:** ${value}`);
+    }
+  }
+  lines.push(`- **মূল পেজ:** ${absoluteUrl(canonicalPath)}`);
+
+  lines.push('', '---', '', body.trim(), '');
+
+  return lines.join('\n');
+}
+
+/** Build a markdown (`text/markdown`) response. */
+export function markdownResponse(content: string): Response {
+  return new Response(content, {
+    headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+  });
+}
+
+/** Build a plain-text (`text/plain`) response, used for llms.txt. */
+export function plainTextResponse(content: string): Response {
+  return new Response(content, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+}

--- a/src/pages/blog/[slug].md.ts
+++ b/src/pages/blog/[slug].md.ts
@@ -1,0 +1,46 @@
+import type { APIRoute } from 'astro';
+import { getCollection, getEntry } from 'astro:content';
+
+import { buildContentMarkdown, markdownResponse } from '@/lib/agentReadable';
+
+// Clean-markdown endpoint for blog posts, e.g. /blog/welcome-to-codealoy.md
+export async function getStaticPaths() {
+  const posts = await getCollection(
+    'blog',
+    ({ data }) => data.status === 'published',
+  );
+
+  return posts.map((post) => ({
+    params: { slug: post.data.slug },
+    props: { slug: post.data.slug },
+  }));
+}
+
+const dateFormatter = new Intl.DateTimeFormat('bn-BD', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+});
+
+export const GET: APIRoute = async ({ props }) => {
+  const { slug } = props as { slug: string };
+
+  const post = await getEntry('blog', slug);
+
+  if (!post) {
+    return new Response('Not found', { status: 404 });
+  }
+
+  const markdown = buildContentMarkdown({
+    title: post.data.title,
+    description: post.data.description,
+    body: post.body ?? '',
+    canonicalPath: `/blog/${post.data.slug}`,
+    meta: {
+      লেখক: post.data.author,
+      প্রকাশ: dateFormatter.format(post.data.publishedAt),
+    },
+  });
+
+  return markdownResponse(markdown);
+};

--- a/src/pages/courses/[course]/[lesson].md.ts
+++ b/src/pages/courses/[course]/[lesson].md.ts
@@ -1,0 +1,37 @@
+import type { APIRoute } from 'astro';
+import { getEntry } from 'astro:content';
+
+import { buildContentMarkdown, markdownResponse } from '@/lib/agentReadable';
+import { getLessonPaths } from '@/lib/courses';
+
+// Clean-markdown endpoint for lessons, e.g.
+// /courses/learn-problem-solving-basic/1-welcome.md
+export async function getStaticPaths() {
+  return await getLessonPaths();
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { courseSlug, lessonSlug } = props as {
+    courseSlug: string;
+    lessonSlug: string;
+  };
+
+  const course = await getEntry('courses', courseSlug);
+  const lesson = await getEntry('lessons', `${courseSlug}/${lessonSlug}`);
+
+  if (!lesson) {
+    return new Response('Not found', { status: 404 });
+  }
+
+  const markdown = buildContentMarkdown({
+    title: lesson.data.title,
+    description: lesson.data.description,
+    body: lesson.body ?? '',
+    canonicalPath: `/courses/${courseSlug}/${lessonSlug}`,
+    meta: {
+      কোর্স: course?.data.title,
+    },
+  });
+
+  return markdownResponse(markdown);
+};

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,0 +1,108 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+
+import { BASE_URL, GITHUB_REPO_LINK } from '@/config/site';
+
+import { absoluteUrl, plainTextResponse } from '@/lib/agentReadable';
+import {
+  createLessonMap,
+  extractCourseSlug,
+  getCourseLessons,
+  getPublishedCourses,
+  organizeLessonsIntoSections,
+  readCourseMeta,
+} from '@/lib/courses';
+
+// llms.txt — an index of the site for AI assistants, following the
+// llmstxt.org convention. Generated from the content collections so it stays
+// in sync with the published courses, lessons and blog posts.
+export const GET: APIRoute = async () => {
+  const lines: string[] = [
+    '# কোডালয় (Codealoy)',
+    '',
+    '> বাংলায় প্রোগ্রামিং আর এজেন্টিক AI ডেভেলপমেন্ট শেখার ওপেন-সোর্স ইন্টার‍্যাক্টিভ প্ল্যাটফর্ম। মূল কথা — AI কোড লেখে, ইঞ্জিনিয়ার সিদ্ধান্ত নেয়।',
+    '',
+    'Codealoy teaches programming and agentic AI development in Bangla (Bengali): prompting, context engineering, agent orchestration and verification. Each lesson and blog post below is also available as clean markdown — append `.md` to its URL for AI-friendly content.',
+    '',
+    `সাইট: ${BASE_URL}`,
+    '',
+  ];
+
+  // Courses + their lessons (clean-markdown links).
+  const courses = await getPublishedCourses();
+
+  lines.push('## কোর্স (Courses)', '');
+  for (const course of courses) {
+    const courseSlug = extractCourseSlug(course.id);
+    const overviewUrl = absoluteUrl(`/courses/${courseSlug}`);
+    lines.push(
+      `- [${course.data.title}](${overviewUrl}): ${course.data.description}`,
+    );
+  }
+  lines.push('');
+
+  for (const course of courses) {
+    const courseSlug = extractCourseSlug(course.id);
+    const meta = readCourseMeta(courseSlug);
+    const lessons = await getCourseLessons(courseSlug);
+    const sections = organizeLessonsIntoSections(
+      meta,
+      createLessonMap(lessons),
+    );
+
+    lines.push(`### ${course.data.title} — অধ্যায়সমূহ`, '');
+    for (const section of sections) {
+      for (const lesson of section.lessons) {
+        const mdUrl = absoluteUrl(`/courses/${courseSlug}/${lesson.slug}.md`);
+        lines.push(`- [${lesson.title}](${mdUrl}): ${section.title}`);
+      }
+    }
+    lines.push('');
+  }
+
+  // Blog posts (clean-markdown links).
+  const posts = await getCollection(
+    'blog',
+    ({ data }) => data.status === 'published',
+  );
+  posts.sort(
+    (a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime(),
+  );
+
+  lines.push('## ব্লগ (Blog)', '');
+  for (const post of posts) {
+    const mdUrl = absoluteUrl(`/blog/${post.data.slug}.md`);
+    lines.push(`- [${post.data.title}](${mdUrl}): ${post.data.description}`);
+  }
+  lines.push('');
+
+  // Skill artifacts.
+  lines.push(
+    '## স্কিল (Skills)',
+    '',
+    `- [স্কিল আর্টিফ্যাক্ট তালিকা](${absoluteUrl('/skills.md')}): কোডালয়ের ইনস্টলযোগ্য স্কিল আর্টিফ্যাক্ট`,
+    '',
+  );
+
+  // Canon that is planned but not published yet.
+  lines.push(
+    '## আসন্ন (Upcoming canon)',
+    '',
+    'এই পেজগুলো এখনো প্রকাশিত হয়নি, শিগগিরই আসছে:',
+    '',
+    '- ম্যানিফেস্টো (Manifesto) — কোডালয়ের অবস্থান ও দর্শন',
+    '- এজেন্টিক ৫০ (Agentic 50) — এজেন্টিক ডেভেলপমেন্ট শেখার রোডম্যাপ',
+    '- মাসিক AI ডেভ ডাইজেস্ট (Monthly AI Dev Digest)',
+    '',
+  );
+
+  // Optional — agents with a limited context budget can skip this section.
+  lines.push(
+    '## Optional',
+    '',
+    `- [GitHub রিপোজিটরি](${GITHUB_REPO_LINK}): কোডালয়ের সোর্স কোড ও কন্টেন্ট`,
+    '',
+  );
+
+  return plainTextResponse(lines.join('\n'));
+};

--- a/src/pages/skills.md.ts
+++ b/src/pages/skills.md.ts
@@ -1,0 +1,55 @@
+import type { APIRoute } from 'astro';
+
+import { SKILLS, SKILLS_REPO_URL } from '@/config/skills';
+
+import { markdownResponse } from '@/lib/agentReadable';
+
+// skills.md — installable Codealoy skill artifacts. Served at /skills.md and
+// generated from src/config/skills.ts.
+export const GET: APIRoute = () => {
+  const available = SKILLS.filter((s) => s.status === 'available');
+  const planned = SKILLS.filter((s) => s.status === 'planned');
+
+  const lines: string[] = [
+    '# কোডালয় স্কিল (Codealoy Skills)',
+    '',
+    '> এজেন্টিক ডেভেলপমেন্টের জন্য কোডালয়ের ইনস্টলযোগ্য স্কিল আর্টিফ্যাক্ট। প্রতিটি স্কিল একটি স্ল্যাশ কমান্ড হিসেবে আপনার AI এজেন্টে (Claude Code, Codex, Cursor) যোগ করা যাবে।',
+    '',
+    `গিটহাব স্কিল রিপোজিটরি (Github Skills Repository): ${SKILLS_REPO_URL}`,
+    '',
+  ];
+
+  if (available.length > 0) {
+    lines.push('## উপলব্ধ (Available)', '');
+    for (const skill of available) {
+      lines.push(
+        `### \`${skill.command}\` — ${skill.name}`,
+        '',
+        skill.description,
+        '',
+        `_${skill.descriptionEn}_`,
+        '',
+        `- ইনস্টল/সোর্স: ${skill.url}`,
+        '',
+      );
+    }
+  }
+
+  if (planned.length > 0) {
+    lines.push('## আসন্ন (Planned)', '');
+    for (const skill of planned) {
+      lines.push(
+        `### \`${skill.command}\` — ${skill.name}`,
+        '',
+        skill.description,
+        '',
+        `${skill.descriptionEn}`,
+        '',
+        '- অবস্থা: তৈরি হচ্ছে (coming soon)',
+        '',
+      );
+    }
+  }
+
+  return markdownResponse(lines.join('\n'));
+};


### PR DESCRIPTION
## Summary

Makes Codealoy's content readable by AI assistants and agents. Closes #144.

- **`/llms.txt`** — an index of the site (courses, lessons, blog) following the [llms.txt](https://llmstxt.org/) convention, served at the site root.
- **Clean markdown content URLs** — append `.md` to lesson and blog URLs to get the raw markdown body wrapped with a small human-readable header (title, description, canonical link, metadata):
  - `src/pages/courses/[course]/[lesson].md.ts`
  - `src/pages/blog/[slug].md.ts`
- **`/skills.md`** — a generated registry of installable Codealoy skill artifacts, driven by `src/config/skills.ts` as the single source of truth.
- **`src/lib/agentReadable.ts`** — shared helpers (`absoluteUrl`, `buildContentMarkdown`, `markdownResponse`, `plainTextResponse`) for the above routes.

## Changes

| File | Purpose |
| --- | --- |
| `src/pages/llms.txt.ts` | Site index for AI assistants |
| `src/pages/courses/[course]/[lesson].md.ts` | Raw markdown for lessons |
| `src/pages/blog/[slug].md.ts` | Raw markdown for blog posts |
| `src/pages/skills.md.ts` | Generated skills registry page |
| `src/config/skills.ts` | Skill artifact registry (source of truth) |
| `src/lib/agentReadable.ts` | Shared markdown/response helpers |

## Test plan

- [x] `pnpm build` succeeds
- [x] `/llms.txt` lists published courses, lessons, and blog posts
- [x] Appending `.md` to a lesson/blog URL returns markdown with the header
- [x] `/skills.md` renders the registry from `skills.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New markdown-formatted endpoints now serve blog posts, course lessons, and skills documentation for improved content accessibility
  * Introduced llms.txt file to help AI assistants discover and navigate available content
  * Launched skills registry system with support for managing available and planned skill artifacts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->